### PR TITLE
feat: Lower contrast of input placeholder text

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,11 @@
       box-shadow: 0 0 0 3px rgb(37 99 235 / 0.1);
     }
 
+    #targetInput::placeholder {
+      color: var(--text-secondary); /* Use the secondary text color for less emphasis */
+      opacity: 0.7; /* Further reduce prominence with opacity */
+    }
+
     .button {
       width: 100%;
       padding: 0.75rem 1.5rem;


### PR DESCRIPTION
Updated CSS in `index.html` to style the placeholder text of the target input field (`#targetInput::placeholder`). The placeholder color is now set to `var(--text-secondary)` and opacity to `0.7` to reduce its visual prominence for better UX, especially within the dark theme.

## 📋 Pull Request Description

### 🎯 What does this PR do?
Brief description of the changes made.

### 🔗 Related Issues
Fixes #(issue number)

### 🧪 Testing
- [ ] I have tested this change locally
- [ ] I have tested in multiple browsers
- [ ] I have verified security implications
- [ ] I have updated documentation if needed

### 📝 Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security improvement

### 🔒 Security Checklist
- [ ] No private keys are logged or transmitted
- [ ] Cryptographic changes maintain BIP32/BIP44 compatibility
- [ ] No new external dependencies that could compromise security
- [ ] Randomness sources remain cryptographically secure

### 📸 Screenshots (if applicable)
Add screenshots of UI changes here.

### 🚀 Performance Impact
- [ ] No performance impact
- [ ] Slight performance improvement
- [ ] Slight performance degradation (justified)
- [ ] Significant performance change (please explain)

### 📱 Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### 📝 Additional Notes
Any additional information or context about this PR.
