### PR TITLE
Revert CSS variables to previous dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,18 +24,18 @@
   <title>MANTRA Vanity Address Generator</title>
   <style>
     :root {
-      --primary-color: #F406F4;
-      --primary-hover: #C004C0;
-      --success-color: #22c55e; /* Unchanged */
-      --error-color: #ef4444; /* Unchanged */
-      --warning-color: #f97316; /* Unchanged */
-      --background: #010101;
-      --surface: #1A1A1A;
-      --text-primary: #AAAAAA;
-      --text-secondary: #616161;
-      --border: #333333;
-      --border-radius: 8px; /* Existing value, explicitly kept */
-      --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.3), 0 1px 2px -1px rgb(0 0 0 / 0.25);
+      --primary-color: #3b82f6;
+      --primary-hover: #2563eb;
+      --success-color: #22c55e;
+      --error-color: #ef4444;
+      --warning-color: #f97316;
+      --background: #1f2937;
+      --surface: #374151;
+      --text-primary: #f3f4f6;
+      --text-secondary: #9ca3af;
+      --border: #4b5563;
+      --border-radius: 8px; /* This should already be 8px */
+      --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.2), 0 1px 2px -1px rgb(0 0 0 / 0.15);
     }
 
     * {


### PR DESCRIPTION
This commit updates the :root CSS variables in index.html to restore the previous dark theme settings as you requested.

The following variables were changed:
- --primary-color
- --primary-hover
- --background
- --surface
- --text-primary
- --text-secondary
- --border
- --shadow

The values for --success-color, --error-color, --warning-color, and --border-radius remained the same as they matched the target theme or were already correct.

## 📋 Pull Request Description

### 🎯 What does this PR do?
Brief description of the changes made.

### 🔗 Related Issues
Fixes #(issue number)

### 🧪 Testing
- [ ] I have tested this change locally
- [ ] I have tested in multiple browsers
- [ ] I have verified security implications
- [ ] I have updated documentation if needed

### 📝 Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security improvement

### 🔒 Security Checklist
- [ ] No private keys are logged or transmitted
- [ ] Cryptographic changes maintain BIP32/BIP44 compatibility
- [ ] No new external dependencies that could compromise security
- [ ] Randomness sources remain cryptographically secure

### 📸 Screenshots (if applicable)
Add screenshots of UI changes here.

### 🚀 Performance Impact
- [ ] No performance impact
- [ ] Slight performance improvement
- [ ] Slight performance degradation (justified)
- [ ] Significant performance change (please explain)

### 📱 Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### 📝 Additional Notes
Any additional information or context about this PR.
