### PR TITLE
feat: Implement mnemonic visibility toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,13 +558,18 @@
       <div class="result-item">
         <span class="result-label">📧 Address:</span>
         <div class="result-value" id="addressValue">
+          <span id="addressText"></span>
           <button class="copy-button" onclick="copyToClipboard('addressValue')">Copy</button>
         </div>
       </div>
 
       <div class="result-item">
-        <span class="result-label">🔑 Mnemonic Phrase:</span>
+        <span class="result-label">
+          🔑 Mnemonic Phrase:
+          <button id="toggleMnemonicVisibilityButton" title="Toggle visibility" style="background: none; border: none; cursor: pointer; margin-left: 5px; vertical-align: middle; font-size: 1em;">👁️</button>
+        </span>
         <div class="result-value" id="mnemonicValue">
+          <span id="mnemonicText"></span>
           <button class="copy-button" onclick="copyToClipboard('mnemonicValue')">Copy</button>
         </div>
       </div>
@@ -576,23 +581,53 @@
   <script>
     // Global utility function for copying to clipboard
     async function copyToClipboard(elementId) {
-      const element = document.getElementById(elementId);
-      const text = element.textContent.replace('Copy', '').trim();
-      
+      let textToCopy = '';
+      if (elementId === 'mnemonicValue') {
+        if (window.vanityApp && typeof window.vanityApp.actualMnemonic === 'string') {
+          textToCopy = window.vanityApp.actualMnemonic;
+        } else {
+          const mnemonicTextElement = document.getElementById('mnemonicText');
+          if (mnemonicTextElement) textToCopy = mnemonicTextElement.textContent;
+          if (textToCopy.includes('•')) {
+            // Avoid copying placeholder if actual mnemonic isn't available for some reason
+            return;
+          }
+        }
+      } else if (elementId === 'addressValue') {
+        const addressTextElement = document.getElementById('addressText');
+        if (addressTextElement) {
+          textToCopy = addressTextElement.textContent;
+        } else {
+          // Should not happen, but good to guard
+          return;
+        }
+      } else {
+        // Unknown ID
+        return;
+      }
+
+      if (!textToCopy) {
+        // If, after all checks, textToCopy is empty (e.g. address not generated yet), do nothing.
+        return;
+      }
+
       try {
-        await navigator.clipboard.writeText(text);
-        const button = element.querySelector('.copy-button');
-        const originalText = button.textContent;
-        button.textContent = '✓';
-        button.style.backgroundColor = 'var(--success-color)';
-        
-        setTimeout(() => {
-          button.textContent = originalText;
-          button.style.backgroundColor = 'var(--primary-color)';
-        }, 2000);
+        await navigator.clipboard.writeText(textToCopy);
+        // Visual feedback
+        const containerElement = document.getElementById(elementId);
+        const button = containerElement.querySelector('.copy-button');
+        if (button) {
+            const originalText = button.textContent;
+            button.textContent = '✓';
+            button.style.backgroundColor = 'var(--success-color)';
+            setTimeout(() => {
+              button.textContent = originalText;
+              button.style.backgroundColor = 'var(--primary-color)';
+            }, 2000);
+        }
       } catch (err) {
-        console.error('Failed to copy text: ', err);
-        alert('Failed to copy to clipboard');
+        // console.error('Failed to copy text: ', err); // Kept for debugging if needed
+        alert('Failed to copy to clipboard.'); // User-friendly message
       }
     }
   </script>

--- a/main.js
+++ b/main.js
@@ -249,12 +249,18 @@ class VanityGeneratorApp {
       generateButton: document.getElementById('generateButton'),
       statusDiv: document.getElementById('status'),
       resultsDiv: document.getElementById('results'),
-      addressValue: document.getElementById('addressValue'),
-      mnemonicValue: document.getElementById('mnemonicValue'),
+      addressValue: document.getElementById('addressValue'), // This is the container div
+      mnemonicValue: document.getElementById('mnemonicValue'), // This is the container div
+      addressTextElement: document.getElementById('addressText'), // For the actual address string
+      mnemonicTextElement: document.getElementById('mnemonicText'), // For the actual mnemonic string or placeholder
+      toggleMnemonicVisibilityButton: document.getElementById('toggleMnemonicVisibilityButton'), // Button to toggle mnemonic
       attemptsValue: document.getElementById('attemptsValue'),
       durationValue: document.getElementById('durationValue'),
       rateValue: document.getElementById('rateValue')
     };
+
+    this.actualMnemonic = ''; // Store the actual mnemonic phrase
+    this.isMnemonicVisible = false; // Track visibility state
   }
 
   /**
@@ -326,6 +332,20 @@ class VanityGeneratorApp {
         this.stopGeneration();
       }
     });
+
+    // Mnemonic visibility toggle
+    if (this.elements.toggleMnemonicVisibilityButton) {
+      this.elements.toggleMnemonicVisibilityButton.addEventListener('click', () => {
+        this.isMnemonicVisible = !this.isMnemonicVisible;
+        if (this.isMnemonicVisible) {
+          this.elements.mnemonicTextElement.textContent = this.actualMnemonic;
+          this.elements.toggleMnemonicVisibilityButton.textContent = '🙈'; // "Hide" icon
+        } else {
+          this.elements.mnemonicTextElement.textContent = '••••••••••••'; // Placeholder
+          this.elements.toggleMnemonicVisibilityButton.textContent = '👁️'; // "Show" icon
+        }
+      });
+    }
   }
 
   /**
@@ -681,8 +701,16 @@ class VanityGeneratorApp {
    * Show generation success
    */
   showSuccess(keypair) {
-    this.elements.addressValue.textContent = keypair.address;
-    this.elements.mnemonicValue.textContent = keypair.mnemonic;
+    this.elements.addressTextElement.textContent = keypair.address; // Update address text
+
+    // Handle mnemonic display and visibility
+    this.actualMnemonic = keypair.mnemonic;
+    this.elements.mnemonicTextElement.textContent = '••••••••••••'; // Show placeholder
+    this.isMnemonicVisible = false;
+    if (this.elements.toggleMnemonicVisibilityButton) {
+        this.elements.toggleMnemonicVisibilityButton.textContent = '👁️'; // Reset to "show" icon
+    }
+
     this.elements.resultsDiv.style.display = 'block';
     
     // Stop animations


### PR DESCRIPTION

## 📋 Pull Request Description

### 🎯 What does this PR do?

This commit introduces a security and usability improvement by hiding the mnemonic phrase by default upon successful vanity address generation.

Key changes:
- Mnemonic phrase is now initially displayed as a placeholder (e.g., "••••••••••••").
- An eye icon button has been added next to the "Mnemonic Phrase" label to toggle the visibility of the actual mnemonic.
- The copy button for the mnemonic now always copies the correct, full mnemonic phrase, regardless of its current visibility state.
- Refactored the display of address and mnemonic in the results section to use dedicated `<span>` elements (`addressText` and `mnemonicText`). This resolves a pre-existing bug where the copy buttons were removed when these values were populated.
- Added minor inline CSS to the toggle button for better vertical alignment and consistent sizing.

The functionality ensures that the sensitive mnemonic phrase is not exposed by default, while providing a clear and easy way for you to view it when needed.

### 🔗 Related Issues
Fixes #(issue number)

### 🧪 Testing
- [ ] I have tested this change locally
- [ ] I have tested in multiple browsers
- [ ] I have verified security implications
- [ ] I have updated documentation if needed

### 📝 Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Security improvement

### 🔒 Security Checklist
- [ ] No private keys are logged or transmitted
- [ ] Cryptographic changes maintain BIP32/BIP44 compatibility
- [ ] No new external dependencies that could compromise security
- [ ] Randomness sources remain cryptographically secure

### 📸 Screenshots (if applicable)
Add screenshots of UI changes here.

### 🚀 Performance Impact
- [ ] No performance impact
- [ ] Slight performance improvement
- [ ] Slight performance degradation (justified)
- [ ] Significant performance change (please explain)

### 📱 Browser Testing
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### 📝 Additional Notes
Any additional information or context about this PR.
